### PR TITLE
Set mux default = 0

### DIFF
--- a/package/lean/luci-app-ssr-plus/root/usr/share/shadowsocksr/subscribe.lua
+++ b/package/lean/luci-app-ssr-plus/root/usr/share/shadowsocksr/subscribe.lua
@@ -135,7 +135,7 @@ local function processData(szType, content)
 		result.alter_id = info.aid
 		result.vmess_id = info.id
 		result.alias = info.ps
--- 		result.mux = 1
+-- 		result.mux = 0
 -- 		result.concurrency = 8
 		if info.net == 'ws' then
 			result.ws_host = info.host


### PR DESCRIPTION
Mux 是为了减少 TCP 的握手延迟而设计，而非提高连接的吞吐量。使用 Mux 看视频、下载或者测速通常都有反效果。

Refer: https://www.v2ray.com/chapter_02/mux.html