### PR TITLE
rockchip: add support for FriendlyARM NanoPi R4S

### DIFF
--- a/package/boot/uboot-rockchip/Makefile
+++ b/package/boot/uboot-rockchip/Makefile
@@ -38,6 +38,16 @@ endef
 
 # RK3399 boards
 
+define U-Boot/nanopi-r4s-rk3399
+  BUILD_SUBTARGET:=armv8
+  NAME:=NanoPi R4S
+  BUILD_DEVICES:= \
+    friendlyarm_nanopi-r4s
+  DEPENDS:=+PACKAGE_u-boot-nanopi-r4s-rk3399:arm-trusted-firmware-rockchip
+  PKG_BUILD_DEPENDS:=arm-trusted-firmware-rockchip
+  ATF:=rk3399_bl31.elf
+endef
+
 define U-Boot/rock-pi-4-rk3399
   BUILD_SUBTARGET:=armv8
   NAME:=Rock Pi 4
@@ -59,6 +69,7 @@ define U-Boot/rockpro64-rk3399
 endef
 
 UBOOT_TARGETS := \
+  nanopi-r4s-rk3399 \
   rock-pi-4-rk3399 \
   rockpro64-rk3399 \
   nanopi-r2s-rk3328

--- a/package/boot/uboot-rockchip/patches/200-rockchip-rk3399-split-nanopi-r4-rk3399-out-of-evb_rk.patch
+++ b/package/boot/uboot-rockchip/patches/200-rockchip-rk3399-split-nanopi-r4-rk3399-out-of-evb_rk.patch
@@ -1,0 +1,513 @@
+From a765bb2678b6d1666caafef0fcf88fba88b5b26f Mon Sep 17 00:00:00 2001
+From: hmz007 <hmz007@gmail.com>
+Date: Fri, 18 Dec 2020 17:10:35 +0800
+Subject: [PATCH] rockchip: rk3399: split nanopi-r4-rk3399 out of evb_rk3399
+
+nanopi-r4-rk3399 board has multiple DDR types. Currently we don't have any code
+are compatible with these devices. Since multiple DDR types is specific to
+nanopi-r4-rk3399 board, split it into its own board file and add code
+support here.
+
+Signed-off-by: hmz007 <hmz007@gmail.com>
+[Improved commit message and Kconfig description]
+Signed-off-by: Tianling Shen <cnsztl@gmail.com>
+---
+ arch/arm/mach-rockchip/rk3399/Kconfig |  15 +++
+ board/friendlyarm/nanopi4/Kconfig     |  15 +++
+ board/friendlyarm/nanopi4/MAINTAINERS |   5 +
+ board/friendlyarm/nanopi4/Makefile    |   8 ++
+ board/friendlyarm/nanopi4/hwrev.c     | 185 ++++++++++++++++++++++++++
+ board/friendlyarm/nanopi4/hwrev.h     |  27 ++++
+ board/friendlyarm/nanopi4/nanopi4.c   | 148 +++++++++++++++++++++
+ drivers/clk/rockchip/clk_rk3399.c     |   2 +
+ include/configs/nanopi4.h             |  28 ++++
+ 9 files changed, 433 insertions(+)
+ create mode 100644 board/friendlyarm/nanopi4/Kconfig
+ create mode 100644 board/friendlyarm/nanopi4/MAINTAINERS
+ create mode 100644 board/friendlyarm/nanopi4/Makefile
+ create mode 100644 board/friendlyarm/nanopi4/hwrev.c
+ create mode 100644 board/friendlyarm/nanopi4/hwrev.h
+ create mode 100644 board/friendlyarm/nanopi4/nanopi4.c
+ create mode 100644 include/configs/nanopi4.h
+
+--- a/arch/arm/mach-rockchip/rk3399/Kconfig
++++ b/arch/arm/mach-rockchip/rk3399/Kconfig
+@@ -109,6 +109,20 @@ config TARGET_ROC_PC_RK3399
+ 	   * wide voltage input(5V-15V), dual cell battery
+ 	   * Wifi/BT accessible via expansion board M.2
+ 
++config TARGET_NANOPI4_RK3399
++	bool "FriendlyElec NanoPi4 board"
++	help
++	  NanoPi4 is SBC produced by FriendlyElec. Key features:
++
++	   * Rockchip RK3399
++	   * 1/2/4GB Dual-Channel DDR3/LPDDR4
++	   * SD card slot
++	   * Gigabit ethernet
++	   * PCIe
++	   * USB 3.0, 2.0
++	   * USB Type C power
++	   * GPIO expansion ports
++
+ endchoice
+ 
+ config ROCKCHIP_BOOT_MODE_REG
+@@ -152,6 +166,7 @@ config SYS_BOOTCOUNT_ADDR
+ endif # BOOTCOUNT_LIMIT
+ 
+ source "board/firefly/roc-pc-rk3399/Kconfig"
++source "board/friendlyarm/nanopi4/Kconfig"
+ source "board/google/gru/Kconfig"
+ source "board/pine64/pinebook-pro-rk3399/Kconfig"
+ source "board/pine64/rockpro64_rk3399/Kconfig"
+--- /dev/null
++++ b/board/friendlyarm/nanopi4/Kconfig
+@@ -0,0 +1,15 @@
++if TARGET_NANOPI4_RK3399
++
++config SYS_BOARD
++	default "nanopi4"
++
++config SYS_VENDOR
++	default "friendlyarm"
++
++config SYS_CONFIG_NAME
++	default "nanopi4"
++
++config BOARD_SPECIFIC_OPTIONS
++	def_bool y
++
++endif
+--- /dev/null
++++ b/board/friendlyarm/nanopi4/MAINTAINERS
+@@ -0,0 +1,5 @@
++NanoPi 4 Series
++M:      FriendlyElec <support@friendlyarm.com>
++S:      Maintained
++F:      board/friendlyarm/nanopi4/
++F:      include/configs/nanopi4.h
+--- /dev/null
++++ b/board/friendlyarm/nanopi4/Makefile
+@@ -0,0 +1,8 @@
++#
++# Copyright (C) Guangzhou FriendlyELEC Computer Tech. Co., Ltd.
++# (http://www.friendlyarm.com)
++#
++# SPDX-License-Identifier:     GPL-2.0+
++#
++
++obj-y	+= nanopi4.o hwrev.o
+--- /dev/null
++++ b/board/friendlyarm/nanopi4/hwrev.c
+@@ -0,0 +1,185 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * Copyright (c) 2020 FriendlyElec Computer Tech. Co., Ltd.
++ * (http://www.friendlyarm.com)
++ */
++
++#include <common.h>
++#include <dm.h>
++#include <linux/delay.h>
++#include <log.h>
++#include <asm/io.h>
++#include <asm/gpio.h>
++#include <asm/arch-rockchip/gpio.h>
++
++/*
++ * ID info:
++ *  ID : Volts : ADC value :   Bucket
++ *  ==   =====   =========   ===========
++ *   0 : 0.102V:        58 :    0 -   81
++ *   1 : 0.211V:       120 :   82 -  150
++ *   2 : 0.319V:       181 :  151 -  211
++ *   3 : 0.427V:       242 :  212 -  274
++ *   4 : 0.542V:       307 :  275 -  342
++ *   5 : 0.666V:       378 :  343 -  411
++ *   6 : 0.781V:       444 :  412 -  477
++ *   7 : 0.900V:       511 :  478 -  545
++ *   8 : 1.023V:       581 :  546 -  613
++ *   9 : 1.137V:       646 :  614 -  675
++ *  10 : 1.240V:       704 :  676 -  733
++ *  11 : 1.343V:       763 :  734 -  795
++ *  12 : 1.457V:       828 :  796 -  861
++ *  13 : 1.576V:       895 :  862 -  925
++ *  14 : 1.684V:       956 :  926 -  989
++ *  15 : 1.800V:      1023 :  990 - 1023
++ */
++static const int id_readings[] = {
++	 81, 150, 211, 274, 342, 411, 477, 545,
++	613, 675, 733, 795, 861, 925, 989, 1023
++};
++
++static int cached_board_id = -1;
++
++#define SARADC_BASE		0xFF100000
++#define SARADC_DATA		(SARADC_BASE + 0)
++#define SARADC_CTRL		(SARADC_BASE + 8)
++
++static u32 get_saradc_value(int chn)
++{
++	int timeout = 0;
++	u32 adc_value = 0;
++
++	writel(0, SARADC_CTRL);
++	udelay(2);
++
++	writel(0x28 | chn, SARADC_CTRL);
++	udelay(50);
++
++	timeout = 0;
++	do {
++		if (readl(SARADC_CTRL) & 0x40) {
++			adc_value = readl(SARADC_DATA) & 0x3FF;
++			goto stop_adc;
++		}
++
++		udelay(10);
++	} while (timeout++ < 100);
++
++stop_adc:
++	writel(0, SARADC_CTRL);
++
++	return adc_value;
++}
++
++static uint32_t get_adc_index(int chn)
++{
++	int i;
++	int adc_reading;
++
++	if (cached_board_id != -1)
++		return cached_board_id;
++
++	adc_reading = get_saradc_value(chn);
++	for (i = 0; i < ARRAY_SIZE(id_readings); i++) {
++		if (adc_reading <= id_readings[i]) {
++			debug("ADC reading %d, ID %d\n", adc_reading, i);
++			cached_board_id = i;
++			return i;
++		}
++	}
++
++	/* should die for impossible value */
++	return 0;
++}
++
++/*
++ * Board revision list: <GPIO4_D1 | GPIO4_D0>
++ *  0b00 - NanoPC-T4
++ *  0b01 - NanoPi M4
++ *
++ * Extended by ADC_IN4
++ * Group A:
++ *  0x04 - NanoPi NEO4
++ *  0x06 - SOC-RK3399
++ *  0x07 - SOC-RK3399 V2
++ *  0x09 - NanoPi R4S 1GB
++ *  0x0A - NanoPi R4S 4GB
++ *
++ * Group B:
++ *  0x21 - NanoPi M4 Ver2.0
++ *  0x22 - NanoPi M4B
++ */
++static int pcb_rev = -1;
++
++void bd_hwrev_init(void)
++{
++#define GPIO4_BASE	0xff790000
++	struct rockchip_gpio_regs *regs = (void *)GPIO4_BASE;
++
++#ifdef CONFIG_SPL_BUILD
++	struct udevice *dev;
++
++	if (uclass_get_device_by_driver(UCLASS_CLK,
++				DM_GET_DRIVER(clk_rk3399), &dev))
++		return;
++#endif
++
++	if (pcb_rev >= 0)
++		return;
++
++	/* D1, D0: input mode */
++	clrbits_le32(&regs->swport_ddr, (0x3 << 24));
++	pcb_rev = (readl(&regs->ext_port) >> 24) & 0x3;
++
++	if (pcb_rev == 0x3) {
++		/* Revision group A: 0x04 ~ 0x13 */
++		pcb_rev = 0x4 + get_adc_index(4);
++
++	} else if (pcb_rev == 0x1) {
++		int idx = get_adc_index(4);
++
++		/* Revision group B: 0x21 ~ 0x2f */
++		if (idx > 0) {
++			pcb_rev = 0x20 + idx;
++		}
++	}
++}
++
++#ifdef CONFIG_SPL_BUILD
++static struct board_ddrtype {
++	int rev;
++	const char *type;
++} ddrtypes[] = {
++	{ 0x00, "lpddr3-samsung-4GB-1866" },
++	{ 0x01, "lpddr3-samsung-4GB-1866" },
++	{ 0x04,   "ddr3-1866" },
++	{ 0x06,   "ddr3-1866" },
++	{ 0x07, "lpddr4-100"  },
++	{ 0x09,   "ddr3-1866" },
++	{ 0x0a, "lpddr4-100"  },
++	{ 0x21, "lpddr4-100"  },
++	{ 0x22,   "ddr3-1866" },
++};
++
++const char *rk3399_get_ddrtype(void) {
++	int i;
++
++	bd_hwrev_init();
++	printf("Board: rev%02x\n", pcb_rev);
++
++	for (i = 0; i < ARRAY_SIZE(ddrtypes); i++) {
++		if (ddrtypes[i].rev == pcb_rev)
++			return ddrtypes[i].type;
++	}
++
++	/* fallback to first subnode (ie, first included dtsi) */
++	return NULL;
++}
++#endif
++
++/* To override __weak symbols */
++u32 get_board_rev(void)
++{
++	return pcb_rev;
++}
++
+--- /dev/null
++++ b/board/friendlyarm/nanopi4/hwrev.h
+@@ -0,0 +1,27 @@
++/*
++ * Copyright (C) Guangzhou FriendlyARM Computer Tech. Co., Ltd.
++ * (http://www.friendlyarm.com)
++ *
++ * This program is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU General Public License
++ * as published by the Free Software Foundation; either version 2
++ * of the License, or (at your option) any later version.
++ *
++ * This program is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
++ * GNU General Public License for more details.
++ *
++ * You should have received a copy of the GNU General Public License
++ * along with this program; if not, you can access it online at
++ * http://www.gnu.org/licenses/gpl-2.0.html.
++ */
++
++#ifndef __BD_HW_REV_H__
++#define __BD_HW_REV_H__
++
++extern void bd_hwrev_config_gpio(void);
++extern void bd_hwrev_init(void);
++extern u32 get_board_rev(void);
++
++#endif /* __BD_HW_REV_H__ */
+--- /dev/null
++++ b/board/friendlyarm/nanopi4/nanopi4.c
+@@ -0,0 +1,148 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * Copyright (c) 2020 FriendlyElec Computer Tech. Co., Ltd.
++ * (http://www.friendlyarm.com)
++ */
++
++#include <common.h>
++#include <dm.h>
++#include <env.h>
++#include <hash.h>
++#include <linux/bitops.h>
++#include <i2c.h>
++#include <init.h>
++#include <net.h>
++#include <netdev.h>
++#include <syscon.h>
++#include <asm/arch-rockchip/bootrom.h>
++#include <asm/arch-rockchip/clock.h>
++#include <asm/arch-rockchip/grf_rk3399.h>
++#include <asm/arch-rockchip/hardware.h>
++#include <asm/arch-rockchip/misc.h>
++#include <asm/io.h>
++#include <asm/setup.h>
++#include <u-boot/sha256.h>
++
++#ifdef CONFIG_MISC_INIT_R
++static void setup_iodomain(void)
++{
++	struct rk3399_grf_regs *grf =
++	    syscon_get_first_range(ROCKCHIP_SYSCON_GRF);
++
++	/* BT565 and AUDIO is in 1.8v domain */
++	rk_setreg(&grf->io_vsel, BIT(0) | BIT(1));
++}
++
++static int __maybe_unused mac_read_from_generic_eeprom(u8 *addr)
++{
++	struct udevice *i2c_dev;
++	int ret;
++
++	/* Microchip 24AA02xxx EEPROMs with EUI-48 Node Identity */
++	ret = i2c_get_chip_for_busnum(2, 0x51, 1, &i2c_dev);
++	if (!ret)
++		ret = dm_i2c_read(i2c_dev, 0xfa, addr, 6);
++
++	return ret;
++}
++
++static void setup_macaddr(void)
++{
++#if CONFIG_IS_ENABLED(CMD_NET)
++	int ret;
++	const char *cpuid = env_get("cpuid#");
++	u8 hash[SHA256_SUM_LEN];
++	int size = sizeof(hash);
++	u8 mac_addr[6];
++	int from_eeprom = 0;
++	int lockdown = 0;
++
++#ifndef CONFIG_ENV_IS_NOWHERE
++	lockdown = env_get_yesno("lockdown") == 1;
++#endif
++	if (lockdown && env_get("ethaddr"))
++		return;
++
++	ret = mac_read_from_generic_eeprom(mac_addr);
++	if (!ret && is_valid_ethaddr(mac_addr)) {
++		eth_env_set_enetaddr("ethaddr", mac_addr);
++		from_eeprom = 1;
++	}
++
++	if (!cpuid) {
++		debug("%s: could not retrieve 'cpuid#'\n", __func__);
++		return;
++	}
++
++	ret = hash_block("sha256", (void *)cpuid, strlen(cpuid), hash, &size);
++	if (ret) {
++		debug("%s: failed to calculate SHA256\n", __func__);
++		return;
++	}
++
++	/* Copy 6 bytes of the hash to base the MAC address on */
++	memcpy(mac_addr, hash, 6);
++
++	/* Make this a valid MAC address and set it */
++	mac_addr[0] &= 0xfe;  /* clear multicast bit */
++	mac_addr[0] |= 0x02;  /* set local assignment bit (IEEE802) */
++
++	if (from_eeprom) {
++		eth_env_set_enetaddr("eth1addr", mac_addr);
++	} else {
++		eth_env_set_enetaddr("ethaddr", mac_addr);
++
++		if (lockdown && env_get("eth1addr"))
++			return;
++
++		/* Ugly, copy another 4 bytes to generate a similar address */
++		memcpy(mac_addr + 2, hash + 8, 4);
++		if (!memcmp(hash + 2, hash + 8, 4))
++			mac_addr[5] ^= 0xff;
++
++		eth_env_set_enetaddr("eth1addr", mac_addr);
++	}
++#endif
++
++	return;
++}
++
++int misc_init_r(void)
++{
++	const u32 cpuid_offset = 0x7;
++	const u32 cpuid_length = 0x10;
++	u8 cpuid[cpuid_length];
++	int ret;
++
++	setup_iodomain();
++
++	ret = rockchip_cpuid_from_efuse(cpuid_offset, cpuid_length, cpuid);
++	if (ret)
++		return ret;
++
++	ret = rockchip_cpuid_set(cpuid, cpuid_length);
++	if (ret)
++		return ret;
++
++	setup_macaddr();
++	bd_hwrev_init();
++
++	return 0;
++}
++#endif
++
++#ifdef CONFIG_SERIAL_TAG
++void get_board_serial(struct tag_serialnr *serialnr)
++{
++	char *serial_string;
++	u64 serial = 0;
++
++	serial_string = env_get("serial#");
++
++	if (serial_string)
++		serial = simple_strtoull(serial_string, NULL, 16);
++
++	serialnr->high = (u32)(serial >> 32);
++	serialnr->low = (u32)(serial & 0xffffffff);
++}
++#endif
+diff --git a/drivers/clk/rockchip/clk_rk3399.c b/drivers/clk/rockchip/clk_rk3399.c
+index 22c373a623..38975c0c65 100644
+--- a/drivers/clk/rockchip/clk_rk3399.c
++++ b/drivers/clk/rockchip/clk_rk3399.c
+@@ -1351,6 +1351,8 @@ static void rkclk_init(struct rockchip_cru *cru)
+ 		     pclk_div << PCLK_PERILP1_DIV_CON_SHIFT |
+ 		     hclk_div << HCLK_PERILP1_DIV_CON_SHIFT |
+ 		     HCLK_PERILP1_PLL_SEL_GPLL << HCLK_PERILP1_PLL_SEL_SHIFT);
++
++	rk3399_saradc_set_clk(cru, 1000000);
+ }
+ #endif
+ 
+--- /dev/null
++++ b/include/configs/nanopi4.h
+@@ -0,0 +1,28 @@
++/* SPDX-License-Identifier: GPL-2.0+ */
++/*
++ * Copyright (C) Guangzhou FriendlyELEC Computer Tech. Co., Ltd.
++ * (http://www.friendlyarm.com)
++ *
++ * (C) Copyright 2016 Rockchip Electronics Co., Ltd
++ */
++
++#ifndef __CONFIG_NANOPI4_H__
++#define __CONFIG_NANOPI4_H__
++
++#define ROCKCHIP_DEVICE_SETTINGS \
++		"stdin=serial,usbkbd\0" \
++		"stdout=serial,vidconsole\0" \
++		"stderr=serial,vidconsole\0"
++
++#include <configs/rk3399_common.h>
++
++#define SDRAM_BANK_SIZE			(2UL << 30)
++
++#define CONFIG_SERIAL_TAG
++#define CONFIG_REVISION_TAG
++
++/* Environment configs */
++#define CONFIG_SYS_MMC_ENV_DEV		1
++#define CONFIG_SYS_MMC_ENV_PART		0
++
++#endif

--- a/package/boot/uboot-rockchip/patches/201-ram-rk3399-Add-support-for-multiple-DDR-types.patch
+++ b/package/boot/uboot-rockchip/patches/201-ram-rk3399-Add-support-for-multiple-DDR-types.patch
@@ -1,0 +1,256 @@
+From a9447b7b60a3c5195d0fabbe5aa9c32d047ec997 Mon Sep 17 00:00:00 2001
+From: hmz007 <hmz007@gmail.com>
+Date: Sat, 19 Dec 2020 19:39:14 +0800
+Subject: [PATCH] ram: rk3399: Add support for multiple DDR types
+
+Move rockchip,sdram-params to named subnode to include
+multiple sdram parameters, and then read the parameters
+(by subnode name, first subnode or current node) before
+rk3399_dmc_init().
+
+Signed-off-by: hmz007 <hmz007@gmail.com>
+---
+ arch/arm/dts/rk3399-sdram-ddr3-1333.dtsi      |  6 ++-
+ arch/arm/dts/rk3399-sdram-ddr3-1600.dtsi      |  5 +-
+ arch/arm/dts/rk3399-sdram-ddr3-1866.dtsi      |  6 ++-
+ .../arm/dts/rk3399-sdram-lpddr3-2GB-1600.dtsi |  3 ++
+ .../arm/dts/rk3399-sdram-lpddr3-4GB-1600.dtsi |  3 ++
+ .../rk3399-sdram-lpddr3-samsung-4GB-1866.dtsi |  3 ++
+ arch/arm/dts/rk3399-sdram-lpddr4-100.dtsi     |  3 ++
+ drivers/ram/rockchip/sdram_rk3399.c           | 49 +++++++++++++++----
+ 8 files changed, 64 insertions(+), 14 deletions(-)
+
+--- a/arch/arm/dts/rk3399-sdram-ddr3-1333.dtsi
++++ b/arch/arm/dts/rk3399-sdram-ddr3-1333.dtsi
+@@ -4,7 +4,9 @@
+  */
+ 
+ &dmc {
+-        rockchip,sdram-params = <
++	ddr3-1333 {
++	u-boot,dm-pre-reloc;
++	rockchip,sdram-params = <
+ 		0x1
+ 		0xa
+ 		0x3
+@@ -1536,5 +1538,5 @@
+ 		0x01010000
+ 		0x00000000
+ 	>;
++	};
+ };
+-
+--- a/arch/arm/dts/rk3399-sdram-ddr3-1600.dtsi
++++ b/arch/arm/dts/rk3399-sdram-ddr3-1600.dtsi
+@@ -4,7 +4,9 @@
+  */
+ 
+ &dmc {
+-        rockchip,sdram-params = <
++	ddr3-1600 {
++	u-boot,dm-pre-reloc;
++	rockchip,sdram-params = <
+ 		0x1
+ 		0xa
+ 		0x3
+@@ -1536,4 +1538,5 @@
+ 		0x01010000
+ 		0x00000000
+ 	>;
++	};
+ };
+--- a/arch/arm/dts/rk3399-sdram-ddr3-1866.dtsi
++++ b/arch/arm/dts/rk3399-sdram-ddr3-1866.dtsi
+@@ -4,7 +4,9 @@
+  */
+ 
+ &dmc {
+-        rockchip,sdram-params = <
++	ddr3-1866 {
++	u-boot,dm-pre-reloc;
++	rockchip,sdram-params = <
+ 		0x1
+ 		0xa
+ 		0x3
+@@ -1536,5 +1538,5 @@
+ 		0x01010000
+ 		0x00000000
+ 	>;
++	};
+ };
+-
+--- a/arch/arm/dts/rk3399-sdram-lpddr3-2GB-1600.dtsi
++++ b/arch/arm/dts/rk3399-sdram-lpddr3-2GB-1600.dtsi
+@@ -5,6 +5,8 @@
+  */
+ 
+ &dmc {
++	lpddr3-2GB-1600 {
++	u-boot,dm-pre-reloc;
+ 	rockchip,sdram-params = <
+ 		0x1
+ 		0xa
+@@ -1537,4 +1539,5 @@
+ 		0x01010000
+ 		0x00000000
+ 	>;
++	};
+ };
+--- a/arch/arm/dts/rk3399-sdram-lpddr3-4GB-1600.dtsi
++++ b/arch/arm/dts/rk3399-sdram-lpddr3-4GB-1600.dtsi
+@@ -4,6 +4,8 @@
+  */
+ 
+ &dmc {
++	lpddr3-4GB-1600 {
++	u-boot,dm-pre-reloc;
+ 	rockchip,sdram-params = <
+ 		0x2
+ 		0xa
+@@ -1536,4 +1538,5 @@
+ 		0x01010000
+ 		0x00000000
+ 	>;
++	};
+ };
+--- a/arch/arm/dts/rk3399-sdram-lpddr3-samsung-4GB-1866.dtsi
++++ b/arch/arm/dts/rk3399-sdram-lpddr3-samsung-4GB-1866.dtsi
+@@ -4,6 +4,8 @@
+  */
+ 
+ &dmc {
++	lpddr3-samsung-4GB-1866 {
++	u-boot,dm-pre-reloc;
+ 	rockchip,sdram-params = <
+ 		0x2
+ 		0xa
+@@ -1543,4 +1545,5 @@
+ 		0x01010000	/* DENALI_PHY_957_DATA */
+ 		0x00000000	/* DENALI_PHY_958_DATA */
+ 	>;
++	};
+ };
+--- a/arch/arm/dts/rk3399-sdram-lpddr4-100.dtsi
++++ b/arch/arm/dts/rk3399-sdram-lpddr4-100.dtsi
+@@ -6,6 +6,8 @@
+  */
+ 
+ &dmc {
++	lpddr4-100 {
++	u-boot,dm-pre-reloc;
+ 	rockchip,sdram-params = <
+ 		0x2
+ 		0xa
+@@ -1538,4 +1540,5 @@
+ 		0x01010000
+ 		0x00000000
+ 	>;
++	};
+ };
+--- a/drivers/ram/rockchip/sdram_rk3399.c
++++ b/drivers/ram/rockchip/sdram_rk3399.c
+@@ -1625,7 +1625,6 @@ static void set_ddr_stride(struct rk3399_pmusgrf_regs *pmusgrf, u32 stride)
+ 	rk_clrsetreg(&pmusgrf->soc_con4, 0x1f << 10, stride << 10);
+ }
+ 
+-#if !defined(CONFIG_RAM_RK3399_LPDDR4)
+ static int data_training_first(struct dram_info *dram, u32 channel, u8 rank,
+ 			       struct rk3399_sdram_params *params)
+ {
+@@ -1715,8 +1714,8 @@ void modify_param(const struct chan_info *chan,
+ 	clrsetbits_le32(&denali_pi_params[76], 0x1 << 24, 0x1 << 24);
+ 	clrsetbits_le32(&denali_pi_params[77], 0x1, 0x1);
+ }
+-#else
+ 
++#if defined(CONFIG_RAM_RK3399_LPDDR4)
+ struct rk3399_sdram_params dfs_cfgs_lpddr4[] = {
+ #include "sdram-rk3399-lpddr4-400.inc"
+ #include "sdram-rk3399-lpddr4-800.inc"
+@@ -3011,20 +3010,40 @@ static int sdram_init(struct dram_info *dram,
+ 	return 0;
+ }
+ 
++__weak const char *rk3399_get_ddrtype(void)
++{
++	return NULL;
++}
++
+ static int rk3399_dmc_ofdata_to_platdata(struct udevice *dev)
+ {
+ #if !CONFIG_IS_ENABLED(OF_PLATDATA)
+ 	struct rockchip_dmc_plat *plat = dev_get_platdata(dev);
++	ofnode node = { .np = NULL };
++	const char *name;
+ 	int ret;
+ 
+-	ret = dev_read_u32_array(dev, "rockchip,sdram-params",
+-				 (u32 *)&plat->sdram_params,
+-				 sizeof(plat->sdram_params) / sizeof(u32));
++	name = rk3399_get_ddrtype();
++	if (name)
++		node = dev_read_subnode(dev, name);
++	if (!ofnode_valid(node)) {
++		debug("Failed to read subnode %s\n", name);
++		node = dev_read_first_subnode(dev);
++	}
++
++	/* fallback to current node */
++	if (!ofnode_valid(node))
++		node = dev_ofnode(dev);
++
++	ret = ofnode_read_u32_array(node, "rockchip,sdram-params",
++				    (u32 *)&plat->sdram_params,
++				    sizeof(plat->sdram_params) / sizeof(u32));
+ 	if (ret) {
+ 		printf("%s: Cannot read rockchip,sdram-params %d\n",
+ 		       __func__, ret);
+ 		return ret;
+ 	}
++
+ 	ret = regmap_init_mem(dev_ofnode(dev), &plat->map);
+ 	if (ret)
+ 		printf("%s: regmap failed %d\n", __func__, ret);
+@@ -3051,18 +3070,20 @@ static int conv_of_platdata(struct udevice *dev)
+ #endif
+ 
+ static const struct sdram_rk3399_ops rk3399_ops = {
+-#if !defined(CONFIG_RAM_RK3399_LPDDR4)
+ 	.data_training_first = data_training_first,
+ 	.set_rate_index = switch_to_phy_index1,
+ 	.modify_param = modify_param,
+ 	.get_phy_index_params = get_phy_index_params,
+-#else
++};
++
++#if defined(CONFIG_RAM_RK3399_LPDDR4)
++static const struct sdram_rk3399_ops lpddr4_ops = {
+ 	.data_training_first = lpddr4_mr_detect,
+ 	.set_rate_index = lpddr4_set_rate,
+ 	.modify_param = lpddr4_modify_param,
+ 	.get_phy_index_params = lpddr4_get_phy_index_params,
+-#endif
+ };
++#endif
+ 
+ static int rk3399_dmc_init(struct udevice *dev)
+ {
+@@ -3081,7 +3102,17 @@ static int rk3399_dmc_init(struct udevice *dev)
+ 		return ret;
+ #endif
+ 
+-	priv->ops = &rk3399_ops;
++	if (params->base.dramtype == LPDDR4) {
++#if defined(CONFIG_RAM_RK3399_LPDDR4)
++		priv->ops = &lpddr4_ops;
++#else
++		printf("LPDDR4 support is disable\n");
++		return -EINVAL;
++#endif
++	} else {
++		priv->ops = &rk3399_ops;
++	}
++
+ 	priv->cic = syscon_get_first_range(ROCKCHIP_SYSCON_CIC);
+ 	priv->grf = syscon_get_first_range(ROCKCHIP_SYSCON_GRF);
+ 	priv->pmu = syscon_get_first_range(ROCKCHIP_SYSCON_PMU);

--- a/package/boot/uboot-rockchip/patches/202-arm-dts-rockchip-rename-and-label-gpio-keys-subnodes.patch
+++ b/package/boot/uboot-rockchip/patches/202-arm-dts-rockchip-rename-and-label-gpio-keys-subnodes.patch
@@ -1,0 +1,38 @@
+From f5c5391cc60a675ba38ece5f62b5d113fd57ee45 Mon Sep 17 00:00:00 2001
+From: Tianling Shen <cnsztl@gmail.com>
+Date: Sun, 27 Dec 2020 05:14:47 +0000
+Subject: [PATCH] arm: dts: rockchip: rename and label gpio-keys subnodes
+
+Current dtsi files does not allow to add new gpio labels
+in device specific dts, so let's rename and label it.
+
+Signed-off-by: Tianling Shen <cnsztl@gmail.com>
+---
+ arch/arm/dts/rk3399-nanopi4.dtsi | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+--- a/arch/arm/dts/rk3399-nanopi4.dtsi
++++ b/arch/arm/dts/rk3399-nanopi4.dtsi
+@@ -99,11 +99,11 @@
+ 		regulator-name = "vbus_typec";
+ 	};
+ 
+-	gpio-keys {
++	keys: gpio-keys {
+ 		compatible = "gpio-keys";
+ 		autorepeat;
+ 		pinctrl-names = "default";
+-		pinctrl-0 = <&power_key>;
++		pinctrl-0 = <&key_pins>;
+ 
+ 		power {
+ 			debounce-interval = <100>;
+@@ -550,7 +550,7 @@
+ 	};
+ 
+ 	rockchip-key {
+-		power_key: power-key {
++		key_pins: key-pins {
+ 			rockchip,pins = <0 RK_PA5 RK_FUNC_GPIO &pcfg_pull_up>;
+ 		};
+ 	};

--- a/package/boot/uboot-rockchip/patches/203-rockchip-rk3399-Add-support-for-FriendlyARM-NanoPi-R.patch
+++ b/package/boot/uboot-rockchip/patches/203-rockchip-rk3399-Add-support-for-FriendlyARM-NanoPi-R.patch
@@ -1,0 +1,297 @@
+From 6997a44b545a60b82031c02ea144abc8df561352 Mon Sep 17 00:00:00 2001
+From: Tianling Shen <cnsztl@gmail.com>
+Date: Fri, 25 Dec 2020 13:11:28 +0000
+Subject: [PATCH] rockchip: rk3399: Add support for FriendlyARM NanoPi R4S
+
+This adds support for the NanoPi R4S from FriendlyArm.
+
+Rockchip RK3399 SoC
+1GB DDR3 or 4GB LPDDR4 RAM
+Gigabit Ethernet (WAN)
+Gigabit Ethernet (PCIe) (LAN)
+USB 3.0 Host Port x 2
+MicroSD slot
+Reset button
+WAN - LAN - SYS LED
+
+Signed-off-by: Tianling Shen <cnsztl@gmail.com>
+Co-authored-by: Jensen Huang <jensenhuang@friendlyarm.com>
+Signed-off-by: Jensen Huang <jensenhuang@friendlyarm.com>
+Co-authored-by: Marty Jones <mj8263788@gmail.com>
+Signed-off-by: Marty Jones <mj8263788@gmail.com>
+---
+ arch/arm/dts/Makefile                      |   1 +
+ arch/arm/dts/rk3399-nanopi-r4s-u-boot.dtsi |   9 ++
+ arch/arm/dts/rk3399-nanopi-r4s.dts         | 163 +++++++++++++++++++++
+ board/friendlyarm/nanopi4/MAINTAINERS      |   6 +
+ configs/nanopi-r4s-rk3399_defconfig        |  62 ++++++++
+ 5 files changed, 241 insertions(+)
+ create mode 100644 arch/arm/dts/rk3399-nanopi-r4s-u-boot.dtsi
+ create mode 100644 arch/arm/dts/rk3399-nanopi-r4s.dts
+ create mode 100644 configs/nanopi-r4s-rk3399_defconfig
+
+--- a/arch/arm/dts/Makefile
++++ b/arch/arm/dts/Makefile
+@@ -130,6 +130,7 @@ dtb-$(CONFIG_ROCKCHIP_RK3399) += \
+ 	rk3399-nanopi-m4.dtb \
+ 	rk3399-nanopi-m4-2gb.dtb \
+ 	rk3399-nanopi-neo4.dtb \
++	rk3399-nanopi-r4s.dtb \
+ 	rk3399-orangepi.dtb \
+ 	rk3399-pinebook-pro.dtb \
+ 	rk3399-puma-haikou.dtb \
+--- /dev/null
++++ b/arch/arm/dts/rk3399-nanopi-r4s-u-boot.dtsi
+@@ -0,0 +1,9 @@
++// SPDX-License-Identifier: GPL-2.0+
++/*
++ * (C) Copyright 2020 Jensen Huang <jensenhuang@friendlyarm.com>
++ */
++
++#include "rk3399-nanopi4-u-boot.dtsi"
++#include "rk3399-sdram-lpddr4-100.dtsi"
++#include "rk3399-sdram-lpddr3-samsung-4GB-1866.dtsi"
++#include "rk3399-sdram-ddr3-1866.dtsi"
+--- /dev/null
++++ b/arch/arm/dts/rk3399-nanopi-r4s.dts
+@@ -0,0 +1,163 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2020 Jensen Huang <jensenhuang@friendlyarm.com>
++ * Copyright (c) 2020 Marty Jones <mj8263788@gmail.com>
++ * Copyright (c) 2020 Tianling Shen <cnsztl@gmail.com>
++ */
++
++/dts-v1/;
++#include "rk3399-nanopi4.dtsi"
++
++/ {
++	model = "FriendlyElec NanoPi R4S";
++	compatible = "friendlyarm,nanopi-r4s", "rockchip,rk3399";
++
++	aliases {
++		led-boot = &sys_led;
++		led-failsafe = &sys_led;
++		led-running = &sys_led;
++		led-upgrade = &sys_led;
++		ethernet1 = &r8169;
++	};
++
++	vdd_5v: vdd-5v {
++		compatible = "regulator-fixed";
++		regulator-name = "vdd_5v";
++		regulator-always-on;
++		regulator-boot-on;
++	};
++
++	fan: pwm-fan {
++		compatible = "pwm-fan";
++		/*
++		 * With 20KHz PWM and an EVERCOOL EC4007H12SA fan, these levels
++		 * work out to 0, ~1200, ~3000, and 5000RPM respectively.
++		 */
++		cooling-levels = <0 12 18 255>;
++		#cooling-cells = <2>;
++		fan-supply = <&vdd_5v>;
++		pwms = <&pwm1 0 50000 0>;
++	};
++};
++
++&cpu_thermal {
++	trips {
++		cpu_warm: cpu_warm {
++			temperature = <55000>;
++			hysteresis = <2000>;
++			type = "active";
++		};
++
++		cpu_hot: cpu_hot {
++			temperature = <65000>;
++			hysteresis = <2000>;
++			type = "active";
++		};
++	};
++
++	cooling-maps {
++		map2 {
++			trip = <&cpu_warm>;
++			cooling-device = <&fan THERMAL_NO_LIMIT 1>;
++		};
++
++		map3 {
++			trip = <&cpu_hot>;
++			cooling-device = <&fan 2 THERMAL_NO_LIMIT>;
++		};
++	};
++};
++
++&emmc_phy {
++	status = "disabled";
++};
++
++&fusb0 {
++	status = "disabled";
++};
++
++&keys {
++	reset {
++		label = "reset";
++		gpios = <&gpio1 RK_PC6 GPIO_ACTIVE_LOW>;
++		linux,code = <KEY_RESTART>;
++		debounce-interval = <50>;
++	};
++};
++
++&key_pins {
++	rockchip,pins =
++		<0 RK_PA5 RK_FUNC_GPIO &pcfg_pull_up>,
++		<1 RK_PC6 RK_FUNC_GPIO &pcfg_pull_up>;
++};
++
++&leds {
++	/delete-node/ status;
++
++	lan_led: led-0 {
++		gpios = <&gpio1 RK_PA1 GPIO_ACTIVE_HIGH>;
++		label = "nanopi-r4s:green:lan";
++	};
++
++	sys_led: led-1 {
++		gpios = <&gpio0 RK_PB5 GPIO_ACTIVE_HIGH>;
++		label = "nanopi-r4s:red:sys";
++	};
++
++	wan_led: led-2 {
++		gpios = <&gpio1 RK_PA0 GPIO_ACTIVE_HIGH>;
++		label = "nanopi-r4s:green:wan";
++	};
++};
++
++&leds_gpio {
++	rockchip,pins =
++		<0 RK_PB5 RK_FUNC_GPIO &pcfg_pull_none>,
++		<1 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>,
++		<1 RK_PA1 RK_FUNC_GPIO &pcfg_pull_none>;
++};
++
++&pcie0 {
++	max-link-speed = <1>;
++	num-lanes = <1>;
++	vpcie3v3-supply = <&vcc3v3_sys>;
++
++	pcie@0 {
++		reg = <0x00000000 0 0 0 0>;
++		#address-cells = <3>;
++		#size-cells = <2>;
++
++		r8169: pcie@0,0 {
++			reg = <0x000000 0 0 0 0>;
++			local-mac-address = [ 00 00 00 00 00 00 ];
++		};
++	};
++};
++
++&sdhci {
++	status = "disabled";
++};
++
++&sdio0 {
++	status = "disabled";
++};
++
++&sdmmc {
++	host-index-min = <1>;
++};
++
++&u2phy0_host {
++	phy-supply = <&vdd_5v>;
++};
++
++&u2phy1_host {
++	status = "disabled";
++};
++
++&usbdrd_dwc3_0 {
++	dr_mode = "host";
++};
++
++&vcc3v3_sys {
++	vin-supply = <&vcc5v0_sys>;
++};
+--- a/board/friendlyarm/nanopi4/MAINTAINERS
++++ b/board/friendlyarm/nanopi4/MAINTAINERS
+@@ -3,3 +3,9 @@ M:      FriendlyElec <support@friendlyarm.com>
+ S:      Maintained
+ F:      board/friendlyarm/nanopi4/
+ F:      include/configs/nanopi4.h
++
++NANOPI-R4S
++M:      Tianling Shen <cnsztl@gmail.com>
++S:      Maintained
++F:      configs/nanopi-r4s-rk3399_defconfig
++F:      arch/arm/dts/rk3399-nanopi-r4s-u-boot.dtsi
+--- /dev/null
++++ b/configs/nanopi-r4s-rk3399_defconfig
+@@ -0,0 +1,62 @@
++CONFIG_ARM=y
++CONFIG_ARCH_ROCKCHIP=y
++CONFIG_SYS_TEXT_BASE=0x00200000
++CONFIG_NR_DRAM_BANKS=1
++CONFIG_ENV_OFFSET=0x3F8000
++CONFIG_ROCKCHIP_RK3399=y
++CONFIG_TARGET_NANOPI4_RK3399=y
++CONFIG_DEBUG_UART_BASE=0xFF1A0000
++CONFIG_DEBUG_UART_CLOCK=24000000
++CONFIG_DEFAULT_DEVICE_TREE="rk3399-nanopi-r4s"
++CONFIG_DEBUG_UART=y
++CONFIG_DEFAULT_FDT_FILE="rockchip/rk3399-nanopi-r4s.dtb"
++CONFIG_MISC_INIT_R=y
++# CONFIG_SPL_RAW_IMAGE_SUPPORT is not set
++CONFIG_SPL_STACK_R=y
++CONFIG_SPL_STACK_R_MALLOC_SIMPLE_LEN=0x10000
++CONFIG_TPL=y
++CONFIG_CMD_BOOTZ=y
++CONFIG_CMD_GPT=y
++CONFIG_CMD_MMC=y
++CONFIG_CMD_USB=y
++# CONFIG_CMD_SETEXPR is not set
++CONFIG_CMD_TIME=y
++CONFIG_SPL_OF_CONTROL=y
++CONFIG_OF_SPL_REMOVE_PROPS="pinctrl-0 pinctrl-names clock-names interrupt-parent assigned-clocks assigned-clock-rates assigned-clock-parents"
++CONFIG_ENV_IS_IN_MMC=y
++CONFIG_SYS_RELOC_GD_ENV_ADDR=y
++CONFIG_ROCKCHIP_GPIO=y
++CONFIG_SYS_I2C_ROCKCHIP=y
++CONFIG_MMC_DW=y
++CONFIG_MMC_DW_ROCKCHIP=y
++CONFIG_MMC_SDHCI=y
++CONFIG_MMC_SDHCI_ROCKCHIP=y
++CONFIG_DM_ETH=y
++CONFIG_ETH_DESIGNWARE=y
++CONFIG_GMAC_ROCKCHIP=y
++CONFIG_PMIC_RK8XX=y
++CONFIG_REGULATOR_PWM=y
++CONFIG_REGULATOR_RK8XX=y
++CONFIG_PWM_ROCKCHIP=y
++CONFIG_RAM_RK3399_LPDDR4=y
++CONFIG_BAUDRATE=1500000
++CONFIG_DEBUG_UART_SHIFT=2
++CONFIG_SYSRESET=y
++CONFIG_USB=y
++CONFIG_USB_XHCI_HCD=y
++CONFIG_USB_XHCI_DWC3=y
++CONFIG_USB_EHCI_HCD=y
++CONFIG_USB_EHCI_GENERIC=y
++CONFIG_USB_KEYBOARD=y
++CONFIG_USB_HOST_ETHER=y
++CONFIG_USB_ETHER_ASIX=y
++CONFIG_USB_ETHER_ASIX88179=y
++CONFIG_USB_ETHER_MCS7830=y
++CONFIG_USB_ETHER_RTL8152=y
++CONFIG_USB_ETHER_SMSC95XX=y
++CONFIG_DM_VIDEO=y
++CONFIG_DISPLAY=y
++CONFIG_VIDEO_ROCKCHIP=y
++CONFIG_DISPLAY_ROCKCHIP_HDMI=y
++CONFIG_SPL_TINY_MEMSET=y
++CONFIG_ERRNO_STR=y

--- a/target/linux/rockchip/Makefile
+++ b/target/linux/rockchip/Makefile
@@ -6,7 +6,7 @@ include $(TOPDIR)/rules.mk
 
 BOARD:=rockchip
 BOARDNAME:=Rockchip
-FEATURES:=ext4 audio usb usbgadget display gpio fpu rootfs-part boot-part squashfs
+FEATURES:=ext4 audio usb usbgadget display gpio fpu pci pcie rootfs-part boot-part squashfs
 SUBTARGETS:=armv8
 
 KERNEL_PATCHVER=5.4

--- a/target/linux/rockchip/armv8/base-files/etc/board.d/01_leds
+++ b/target/linux/rockchip/armv8/base-files/etc/board.d/01_leds
@@ -9,7 +9,8 @@ boardname="${board##*,}"
 board_config_update
 
 case $board in
-friendlyarm,nanopi-r2s)
+friendlyarm,nanopi-r2s|\
+friendlyarm,nanopi-r4s)
 	ucidef_set_led_netdev "wan" "WAN" "$boardname:green:wan" "eth0"
 	ucidef_set_led_netdev "lan" "LAN" "$boardname:green:lan" "eth1"
 	;;

--- a/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
+++ b/target/linux/rockchip/armv8/base-files/etc/board.d/02_network
@@ -8,7 +8,8 @@ rockchip_setup_interfaces()
 	local board="$1"
 
 	case "$board" in
-	friendlyarm,nanopi-r2s)
+	friendlyarm,nanopi-r2s|\
+	friendlyarm,nanopi-r4s)
 		ucidef_set_interfaces_lan_wan 'eth1' 'eth0'
 		;;
 	*)
@@ -25,7 +26,8 @@ rockchip_setup_macs()
 	local label_mac=""
 
 	case "$board" in
-	friendlyarm,nanopi-r2s)
+	friendlyarm,nanopi-r2s|\
+	friendlyarm,naonpi-r4s)
 		wan_mac=$(macaddr_random)
 		lan_mac=$(macaddr_add "$wan_mac" +1)
 		;;

--- a/target/linux/rockchip/armv8/base-files/etc/hotplug.d/net/40-net-smp-affinity
+++ b/target/linux/rockchip/armv8/base-files/etc/hotplug.d/net/40-net-smp-affinity
@@ -26,5 +26,9 @@ friendlyarm,nanopi-r2s)
 	set_interface_core 2 "eth0"
 	set_interface_core 4 "eth1" "xhci-hcd:usb3"
 	;;
+friendlyarm,nanopi-r4s)
+	set_interface_core 10 "eth0"
+	set_interface_core 20 "eth1"
+	;;
 esac
 

--- a/target/linux/rockchip/image/armv8.mk
+++ b/target/linux/rockchip/image/armv8.mk
@@ -16,6 +16,16 @@ define Device/friendlyarm_nanopi-r2s
 endef
 TARGET_DEVICES += friendlyarm_nanopi-r2s
 
+define Device/friendlyarm_nanopi-r4s
+  DEVICE_VENDOR := FriendlyARM
+  DEVICE_MODEL := NanoPi R4S
+  SOC := rk3399
+  UBOOT_DEVICE_NAME := nanopi-r4s-rk3399
+  IMAGE/sysupgrade.img.gz := boot-common | boot-script nanopi-r4s | pine64-img | gzip | append-metadata
+  DEVICE_PACKAGES := kmod-r8169
+endef
+TARGET_DEVICES += friendlyarm_nanopi-r4s
+
 define Device/pine64_rockpro64
   DEVICE_VENDOR := Pine64
   DEVICE_MODEL := RockPro64

--- a/target/linux/rockchip/image/nanopi-r4s.bootscript
+++ b/target/linux/rockchip/image/nanopi-r4s.bootscript
@@ -1,0 +1,8 @@
+part uuid mmc ${devnum}:2 uuid
+
+setenv bootargs "console=ttyS2,1500000 earlycon=uart8250,mmio32,0xff1a0000 root=PARTUUID=${uuid} rw rootwait"
+
+load mmc ${devnum}:1 ${fdt_addr_r} rockchip.dtb
+load mmc ${devnum}:1 ${kernel_addr_r} kernel.img
+
+booti ${kernel_addr_r} - ${fdt_addr_r}

--- a/target/linux/rockchip/patches-5.4/200-arm64-dts-rockchip-rename-and-label-gpio-keys-subnod.patch
+++ b/target/linux/rockchip/patches-5.4/200-arm64-dts-rockchip-rename-and-label-gpio-keys-subnod.patch
@@ -1,0 +1,38 @@
+From 14b845b26c9ab88672d164a7ed86773d6eb9ed3f Mon Sep 17 00:00:00 2001
+From: Tianling Shen <cnsztl@gmail.com>
+Date: Sun, 27 Dec 2020 05:37:26 +0000
+Subject: [PATCH] arm64: dts: rockchip: rename and label gpio-keys subnodes
+
+Current dtsi files does not allow to add new gpio labels
+in device specific dts, so let's rename and label it.
+
+Signed-off-by: Tianling Shen <cnsztl@gmail.com>
+---
+ arch/arm64/boot/dts/rockchip/rk3399-nanopi4.dtsi | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+--- a/arch/arm64/boot/dts/rockchip/rk3399-nanopi4.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3399-nanopi4.dtsi
+@@ -78,11 +78,11 @@
+ 		regulator-name = "vbus_typec";
+ 	};
+ 
+-	gpio-keys {
++	keys: gpio-keys {
+ 		compatible = "gpio-keys";
+ 		autorepeat;
+ 		pinctrl-names = "default";
+-		pinctrl-0 = <&power_key>;
++		pinctrl-0 = <&key_pins>;
+ 
+ 		power {
+ 			debounce-interval = <100>;
+@@ -519,7 +519,7 @@
+ 	};
+ 
+ 	rockchip-key {
+-		power_key: power-key {
++		key_pins: key-pins {
+ 			rockchip,pins = <0 RK_PA5 RK_FUNC_GPIO &pcfg_pull_up>;
+ 		};
+ 	};

--- a/target/linux/rockchip/patches-5.4/201-rockchip-rk3399-Add-support-for-FriendlyARM-NanoPi-R.patch
+++ b/target/linux/rockchip/patches-5.4/201-rockchip-rk3399-Add-support-for-FriendlyARM-NanoPi-R.patch
@@ -1,0 +1,203 @@
+From 67180d1b17d881b5d545650ae2894139754f94e4 Mon Sep 17 00:00:00 2001
+From: Tianling Shen <cnsztl@gmail.com>
+Date: Fri, 25 Dec 2020 11:55:35 +0000
+Subject: [PATCH] rockchip: rk3399: Add support for FriendlyARM NanoPi R4S
+
+This adds support for the NanoPi R4S from FriendlyArm.
+
+Rockchip RK3399 SoC
+1GB DDR3 or 4GB LPDDR4 RAM
+Gigabit Ethernet (WAN)
+Gigabit Ethernet (PCIe) (LAN)
+USB 3.0 Host Port x 2
+MicroSD slot
+Reset button
+WAN - LAN - SYS LED
+
+Signed-off-by: Tianling Shen <cnsztl@gmail.com>
+Co-authored-by: Jensen Huang <jensenhuang@friendlyarm.com>
+Signed-off-by: Jensen Huang <jensenhuang@friendlyarm.com>
+Co-authored-by: Marty Jones <mj8263788@gmail.com>
+Signed-off-by: Marty Jones <mj8263788@gmail.com>
+---
+ arch/arm64/boot/dts/rockchip/Makefile         |   1 +
+ .../boot/dts/rockchip/rk3399-nanopi-r4s.dts   | 163 ++++++++++++++++++
+ 2 files changed, 164 insertions(+)
+ create mode 100644 arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dts
+
+--- a/arch/arm64/boot/dts/rockchip/Makefile
++++ b/arch/arm64/boot/dts/rockchip/Makefile
+@@ -25,6 +25,7 @@ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-leez-p710.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-nanopc-t4.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-nanopi-m4.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-nanopi-neo4.dtb
++dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-nanopi-r4s.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-orangepi.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-puma-haikou.dtb
+ dtb-$(CONFIG_ARCH_ROCKCHIP) += rk3399-roc-pc.dtb
+--- /dev/null
++++ b/arch/arm64/boot/dts/rockchip/rk3399-nanopi-r4s.dts
+@@ -0,0 +1,163 @@
++// SPDX-License-Identifier: (GPL-2.0+ OR MIT)
++/*
++ * Copyright (c) 2020 Jensen Huang <jensenhuang@friendlyarm.com>
++ * Copyright (c) 2020 Marty Jones <mj8263788@gmail.com>
++ * Copyright (c) 2020 Tianling Shen <cnsztl@gmail.com>
++ */
++
++/dts-v1/;
++#include "rk3399-nanopi4.dtsi"
++
++/ {
++	model = "FriendlyElec NanoPi R4S";
++	compatible = "friendlyarm,nanopi-r4s", "rockchip,rk3399";
++
++	aliases {
++		led-boot = &sys_led;
++		led-failsafe = &sys_led;
++		led-running = &sys_led;
++		led-upgrade = &sys_led;
++		ethernet1 = &r8169;
++	};
++
++	vdd_5v: vdd-5v {
++		compatible = "regulator-fixed";
++		regulator-name = "vdd_5v";
++		regulator-always-on;
++		regulator-boot-on;
++	};
++
++	fan: pwm-fan {
++		compatible = "pwm-fan";
++		/*
++		 * With 20KHz PWM and an EVERCOOL EC4007H12SA fan, these levels
++		 * work out to 0, ~1200, ~3000, and 5000RPM respectively.
++		 */
++		cooling-levels = <0 12 18 255>;
++		#cooling-cells = <2>;
++		fan-supply = <&vdd_5v>;
++		pwms = <&pwm1 0 50000 0>;
++	};
++};
++
++&cpu_thermal {
++	trips {
++		cpu_warm: cpu_warm {
++			temperature = <55000>;
++			hysteresis = <2000>;
++			type = "active";
++		};
++
++		cpu_hot: cpu_hot {
++			temperature = <65000>;
++			hysteresis = <2000>;
++			type = "active";
++		};
++	};
++
++	cooling-maps {
++		map2 {
++			trip = <&cpu_warm>;
++			cooling-device = <&fan THERMAL_NO_LIMIT 1>;
++		};
++
++		map3 {
++			trip = <&cpu_hot>;
++			cooling-device = <&fan 2 THERMAL_NO_LIMIT>;
++		};
++	};
++};
++
++&emmc_phy {
++	status = "disabled";
++};
++
++&fusb0 {
++	status = "disabled";
++};
++
++&keys {
++	reset {
++		label = "reset";
++		gpios = <&gpio1 RK_PC6 GPIO_ACTIVE_LOW>;
++		linux,code = <KEY_RESTART>;
++		debounce-interval = <50>;
++	};
++};
++
++&key_pins {
++	rockchip,pins =
++		<0 RK_PA5 RK_FUNC_GPIO &pcfg_pull_up>,
++		<1 RK_PC6 RK_FUNC_GPIO &pcfg_pull_up>;
++};
++
++&leds {
++	/delete-node/ status;
++
++	lan_led: led-0 {
++		gpios = <&gpio1 RK_PA1 GPIO_ACTIVE_HIGH>;
++		label = "nanopi-r4s:green:lan";
++	};
++
++	sys_led: led-1 {
++		gpios = <&gpio0 RK_PB5 GPIO_ACTIVE_HIGH>;
++		label = "nanopi-r4s:red:sys";
++	};
++
++	wan_led: led-2 {
++		gpios = <&gpio1 RK_PA0 GPIO_ACTIVE_HIGH>;
++		label = "nanopi-r4s:green:wan";
++	};
++};
++
++&leds_gpio {
++	rockchip,pins =
++		<0 RK_PB5 RK_FUNC_GPIO &pcfg_pull_none>,
++		<1 RK_PA0 RK_FUNC_GPIO &pcfg_pull_none>,
++		<1 RK_PA1 RK_FUNC_GPIO &pcfg_pull_none>;
++};
++
++&pcie0 {
++	max-link-speed = <1>;
++	num-lanes = <1>;
++	vpcie3v3-supply = <&vcc3v3_sys>;
++
++	pcie@0 {
++		reg = <0x00000000 0 0 0 0>;
++		#address-cells = <3>;
++		#size-cells = <2>;
++
++		r8169: pcie@0,0 {
++			reg = <0x000000 0 0 0 0>;
++			local-mac-address = [ 00 00 00 00 00 00 ];
++		};
++	};
++};
++
++&sdhci {
++	status = "disabled";
++};
++
++&sdio0 {
++	status = "disabled";
++};
++
++&sdmmc {
++	host-index-min = <1>;
++};
++
++&u2phy0_host {
++	phy-supply = <&vdd_5v>;
++};
++
++&u2phy1_host {
++	status = "disabled";
++};
++
++&usbdrd_dwc3_0 {
++	dr_mode = "host";
++};
++
++&vcc3v3_sys {
++	vin-supply = <&vcc5v0_sys>;
++};


### PR DESCRIPTION
<h2>Hardware</h2>

RockChip RK3399 ARM64 (6 cores)
1GB DDR3 or 4GB LPDDR4 RAM
2x 1000 Base-T
3 LEDs (LAN / WAN / SYS)
1 Button (Reset)
Micro-SD slot
2x USB 3.0 Port

<h2>Installation</h2>

Uncompress the OpenWrt sysupgrade and write it to a micro SD card using
dd.

<h2>Thanks</h2>

@Aes64X - for led lable definitions
@blackfacem  - for testing
@friendlyarm & @mj22226 - for original source code
@jayanta525 - for boot script
@nicksun98 - for special thanks
@quintus-lab - for IRQ settings and testing